### PR TITLE
Revise PyCaret recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - pyldavis
     - pyod
     - python >=3.6
-    - scikit-learn >=0.23
+    - scikit-learn >=0.23, <=0.23.2
     - scipy <=1.5.4
     - spacy <2.4.0
     - textblob


### PR DESCRIPTION
Revised PyCaret recipe to limit scikit-learn version to between 0.23 and 0.23.2 (inclusive).  This will address the many issues relating to scikit-learn >=24.0, which is installed by the current version of this recipe.  This resolves a number of StackOverflow-reported issues, and the following PyCaret issues:
* https://github.com/pycaret/pycaret/issues/823
* https://github.com/pycaret/pycaret/issues/1204

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ x ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
resolves #823, resolves #1204
-->

<!--
Please add any other relevant info below:
Revised PyCaret recipe to limit scikit-learn version to between 0.23 and 0.23.2 (inclusive).  This will address the many issues relating to scikit-learn >=24.0, which is installed by the current version of this recipe.  This resolves a number of StackOverflow-reported issues, and the following PyCaret issues:
* pycaret/pycaret#823
* pycaret/pycaret#1204
-->
